### PR TITLE
Dev deep conf in scaffolding

### DIFF
--- a/examples/scaffolding/contrib/AsyncGeneration/stream_generation_controller.py
+++ b/examples/scaffolding/contrib/AsyncGeneration/stream_generation_controller.py
@@ -42,8 +42,7 @@ class NativeStreamGenerationController(Controller):
                     "custom_sampling_params")
             elif self.custom_sampling_params:
                 task.custom_sampling_params = self.custom_sampling_params
-            stream_task = StreamGenerationTask()
-            stream_task.__dict__ = copy.deepcopy(task.__dict__)
+            stream_task = StreamGenerationTask.create_from_generation_task(task)
             stream_task.streaming_step = self.stream_step
             stream_tasks.append(stream_task)
         lst = list(range(len(stream_tasks)))

--- a/examples/scaffolding/contrib/DeepConf/run_generation.py
+++ b/examples/scaffolding/contrib/DeepConf/run_generation.py
@@ -30,25 +30,31 @@ def run_scaffolding_llm(prompts, proposer_worker, controller):
     llm.shutdown(shutdown_workers=False)
 
 
-def test_offline_controller(prompts, proposer_worker):
-    prototype_controller = DeepConfOfflineController(conf_group_size=10,
-                                                     conf_threshold=0.5,
-                                                     logprobs_topk=20,
-                                                     sampling_params={
-                                                         "temperature": 0.9,
-                                                         "max_tokens": 1024,
-                                                     })
+def test_offline_controller(prompts, proposer_worker, logprobs_topk=20):
+    prototype_controller = DeepConfOfflineController(
+        conf_group_size=10,
+        conf_threshold=0.5,
+        logprobs_topk=logprobs_topk,
+        sampling_params={
+            "temperature": 0.9,
+            "max_tokens": 1024,
+            "num_logprobs": logprobs_topk,
+        })
 
     run_scaffolding_llm(prompts, proposer_worker, prototype_controller)
 
 
-def test_online_controller(prompts, proposer_worker):
+def test_online_controller(prompts, proposer_worker, logprobs_topk=20):
     prototype_controller = DeepConfOnlineController(conf_group_size=10,
                                                     conf_threshold=0.5,
-                                                    logprobs_topk=20,
+                                                    logprobs_topk=logprobs_topk,
                                                     sampling_params={
-                                                        "temperature": 0.9,
-                                                        "max_tokens": 1024,
+                                                        "temperature":
+                                                        0.9,
+                                                        "max_tokens":
+                                                        1024,
+                                                        "num_logprobs":
+                                                        logprobs_topk,
                                                     })
 
     run_scaffolding_llm(prompts, proposer_worker, prototype_controller)
@@ -70,8 +76,9 @@ def main():
         max_num_tokens=4096,
     )
 
-    test_offline_controller(prompts, llm_worker)
-    test_online_controller(prompts, llm_worker)
+    logprobs_topk = 20
+    test_offline_controller(prompts, llm_worker, logprobs_topk=logprobs_topk)
+    test_online_controller(prompts, llm_worker, logprobs_topk=logprobs_topk)
 
     llm_worker.shutdown()
     print('llm worker shutdown done')

--- a/examples/scaffolding/contrib/DeepConf/run_generation.py
+++ b/examples/scaffolding/contrib/DeepConf/run_generation.py
@@ -1,8 +1,10 @@
 import argparse
 
-from tensorrt_llm.scaffolding import ScaffoldingLlm, TRTLLMWorker
+from tensorrt_llm.scaffolding import (NativeGenerationController,
+                                      ScaffoldingLlm, TRTLLMWorker)
 from tensorrt_llm.scaffolding.contrib.DeepConf import (
-    DeepConfOfflineController, DeepConfOnlineController)
+    DeepConfOfflineController, DeepConfOfflineMajorityVoteController,
+    DeepConfOnlineController)
 
 
 def parse_arguments():
@@ -13,20 +15,25 @@ def parse_arguments():
         type=str,
         required=True,
         help="Path to the directory containing the generation model")
+    parser.add_argument('--run_type',
+                        type=str,
+                        required=True,
+                        help="Type of the run")
     args = parser.parse_args()
     return args
 
 
 def run_scaffolding_llm(prompts, proposer_worker, controller):
-    print('run_scaffolding_llm')
     llm = ScaffoldingLlm(
         controller,
-        {controller.WorkerTag.GENERATION: proposer_worker},
+        {
+            controller.WorkerTag.GENERATION: proposer_worker,
+            NativeGenerationController.WorkerTag.GENERATION: proposer_worker,
+        },
     )
-    print('run_scaffolding_llm 22222')
     results = llm.generate(prompts)
-    for result in results:
-        print(result.outputs[0].text)
+    for i, result in enumerate(results):
+        print(f"result {i}:\n{result.outputs[0].text}")
     llm.shutdown(shutdown_workers=False)
 
 
@@ -60,8 +67,28 @@ def test_online_controller(prompts, proposer_worker, logprobs_topk=20):
     run_scaffolding_llm(prompts, proposer_worker, prototype_controller)
 
 
+def test_offline_majority_vote_controller(prompts, proposer_worker, **kwargs):
+
+    prototype_generation_controller = NativeGenerationController(
+        sampling_params={
+            "max_tokens": 8192,
+            "temperature": 0.9,
+            "num_logprobs": kwargs.get("logprobs_topk", 20),
+        })
+    majority_vote_controller = DeepConfOfflineMajorityVoteController(
+        generation_controller=prototype_generation_controller,
+        sample_num=kwargs.get("sample_num", 10),
+        conf_group_size=kwargs.get("conf_group_size", 10),
+        conf_threshold=kwargs.get("conf_threshold", 0.5),
+        vote_policy=kwargs.get("vote_policy", "majority"),
+    )
+
+    run_scaffolding_llm(prompts, proposer_worker, majority_vote_controller)
+
+
 def main():
     args = parse_arguments()
+    logprobs_topk = 20
 
     prompts = [
         "Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?\r\n\r\n",
@@ -73,12 +100,18 @@ def main():
         args.model_dir,
         backend="pytorch",
         max_batch_size=32,
-        max_num_tokens=4096,
+        max_num_tokens=8192,
     )
-
-    logprobs_topk = 20
-    test_offline_controller(prompts, llm_worker, logprobs_topk=logprobs_topk)
-    test_online_controller(prompts, llm_worker, logprobs_topk=logprobs_topk)
+    if args.run_type == "offline":
+        test_offline_controller(prompts,
+                                llm_worker,
+                                logprobs_topk=logprobs_topk)
+    elif args.run_type == "online":
+        test_online_controller(prompts, llm_worker, logprobs_topk=logprobs_topk)
+    elif args.run_type == "offline_majority_vote":
+        test_offline_majority_vote_controller(prompts, llm_worker)
+    else:
+        raise ValueError(f"Invalid run type: {args.run_type}")
 
     llm_worker.shutdown()
     print('llm worker shutdown done')

--- a/examples/scaffolding/contrib/DeepConf/run_generation.py
+++ b/examples/scaffolding/contrib/DeepConf/run_generation.py
@@ -1,0 +1,81 @@
+import argparse
+
+from tensorrt_llm.scaffolding import ScaffoldingLlm, TRTLLMWorker
+from tensorrt_llm.scaffolding.contrib.DeepConf import (
+    DeepConfOfflineController, DeepConfOnlineController)
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    # .e.g. DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B
+    parser.add_argument(
+        '--model_dir',
+        type=str,
+        required=True,
+        help="Path to the directory containing the generation model")
+    args = parser.parse_args()
+    return args
+
+
+def run_scaffolding_llm(prompts, proposer_worker, controller):
+    print('run_scaffolding_llm')
+    llm = ScaffoldingLlm(
+        controller,
+        {controller.WorkerTag.GENERATION: proposer_worker},
+    )
+    print('run_scaffolding_llm 22222')
+    results = llm.generate(prompts)
+    for result in results:
+        print(result.outputs[0].text)
+    llm.shutdown(shutdown_workers=False)
+
+
+def test_offline_controller(prompts, proposer_worker):
+    prototype_controller = DeepConfOfflineController(conf_group_size=10,
+                                                     conf_threshold=0.5,
+                                                     logprobs_topk=20,
+                                                     sampling_params={
+                                                         "temperature": 0.9,
+                                                         "max_tokens": 1024,
+                                                     })
+
+    run_scaffolding_llm(prompts, proposer_worker, prototype_controller)
+
+
+def test_online_controller(prompts, proposer_worker):
+    prototype_controller = DeepConfOnlineController(conf_group_size=10,
+                                                    conf_threshold=0.5,
+                                                    logprobs_topk=20,
+                                                    sampling_params={
+                                                        "temperature": 0.9,
+                                                        "max_tokens": 1024,
+                                                    })
+
+    run_scaffolding_llm(prompts, proposer_worker, prototype_controller)
+
+
+def main():
+    args = parse_arguments()
+
+    prompts = [
+        "Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?\r\n\r\n",
+        "There exist real numbers $x$ and $y$, both greater than 1, such that $\\log_x\\left(y^x\\right)=\\log_y\\left(x^{4y}\\right)=10$. Find $xy$.",
+        "Find the largest possible real part of \\[(75+117i)z+\\frac{96+144i}{z}\\]where $z$ is a complex number with $|z|=4$.",
+    ]
+
+    llm_worker = TRTLLMWorker.init_with_new_llm(
+        args.model_dir,
+        backend="pytorch",
+        max_batch_size=32,
+        max_num_tokens=4096,
+    )
+
+    test_offline_controller(prompts, llm_worker)
+    test_online_controller(prompts, llm_worker)
+
+    llm_worker.shutdown()
+    print('llm worker shutdown done')
+
+
+if __name__ == "__main__":
+    main()

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -182,12 +182,15 @@ class GenerationExecutorProxy(GenerationExecutor):
             else:
                 queue.put(res)
 
+            if not event_loop.is_running():
+                print(f"wrong: {res}")
             # FIXME: Add type annotations and make 'res' type more homogeneous (e.g.
             #        include PostprocWorker.Output in is_llm_response and unify is_final APIs).
             if (is_llm_response(res) and res.result.is_final) or isinstance(
                     res,
                     ErrorResponse) or (isinstance(res, PostprocWorker.Output)
                                        and res.is_final):
+                # print(f"{client_id=} is final")
                 self._results.pop(client_id)
 
         res = res if isinstance(res, list) else [res]

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -202,7 +202,12 @@ class GenerationExecutorProxy(GenerationExecutor):
             process_res(i)
 
         if async_queues:
-            _SyncQueue.notify_many(event_loop, async_queues)
+            try:
+                _SyncQueue.notify_many(event_loop, async_queues)
+            except AsyncQueue.EventLoopShutdownError:
+                logger.debug(
+                    "proxy.py: EventLoopShutdownError because event loop is not running"
+                )
 
         return True  # success
 

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -321,8 +321,8 @@ class SamplingParams:
             self.guided_decoding._validate()
 
         # correct types as users might pass in logprob=True for Top-1 logprobs
-        # self.logprobs = self.logprobs and int(self.logprobs)
-        # self.prompt_logprobs = self.prompt_logprobs and int(self.prompt_logprobs)
+        self.logprobs = self.logprobs and int(self.logprobs)
+        self.prompt_logprobs = self.prompt_logprobs and int(self.prompt_logprobs)
 
     @property
     def _greedy_decoding(self) -> bool:

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -321,8 +321,8 @@ class SamplingParams:
             self.guided_decoding._validate()
 
         # correct types as users might pass in logprob=True for Top-1 logprobs
-        self.logprobs = self.logprobs and int(self.logprobs)
-        self.prompt_logprobs = self.prompt_logprobs and int(self.prompt_logprobs)
+        # self.logprobs = self.logprobs and int(self.logprobs)
+        # self.prompt_logprobs = self.prompt_logprobs and int(self.prompt_logprobs)
 
     @property
     def _greedy_decoding(self) -> bool:

--- a/tensorrt_llm/scaffolding/__init__.py
+++ b/tensorrt_llm/scaffolding/__init__.py
@@ -6,7 +6,8 @@ from .controller import (BestOfNController, Controller, MajorityVoteController,
 from .math_utils import (extract_answer_from_boxed, extract_answer_with_regex,
                          get_digit_majority_vote_result)
 from .scaffolding_llm import ScaffoldingLlm
-from .task import GenerationTask, RewardTask, Task, TaskStatus
+from .task import (GenerationTask, RewardTask, StreamGenerationTask, Task,
+                   TaskStatus)
 from .task_collection import (GenerationTokenCounter, TaskCollection,
                               with_task_collection)
 from .worker import OpenaiWorker, TRTLLMWorker, TRTOpenaiWorker, Worker
@@ -22,6 +23,7 @@ __all__ = [
     "BestOfNController",
     "Task",
     "GenerationTask",
+    "StreamGenerationTask",
     "RewardTask",
     "Worker",
     "OpenaiWorker",

--- a/tensorrt_llm/scaffolding/contrib/AsyncGeneration/stream_generation.py
+++ b/tensorrt_llm/scaffolding/contrib/AsyncGeneration/stream_generation.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -21,6 +22,12 @@ class StreamGenerationTask(GenerationTask):
     request_handle: Any = field(default=None)
     # worker set this field to True when the generation is finished
     end_flag: bool = field(default=False)
+
+    @staticmethod
+    def create_from_generation_task(task: GenerationTask) -> "StreamGenerationTask":
+        stream_task = StreamGenerationTask()
+        stream_task.__dict__ = copy.deepcopy(task.__dict__)
+        return stream_task
 
 
 async def stream_generation_handler(worker,

--- a/tensorrt_llm/scaffolding/contrib/DeepConf/__init__.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepConf/__init__.py
@@ -1,0 +1,3 @@
+from .deep_conf_controller import DeepConfOfflineController, DeepConfMajorityVoteController, DeepConfOnlineController, AdaptiveMajorityVoteController
+
+__all__ = ["DeepConfOfflineController", "DeepConfMajorityVoteController", "DeepConfOnlineController", "AdaptiveMajorityVoteController"]

--- a/tensorrt_llm/scaffolding/contrib/DeepConf/__init__.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepConf/__init__.py
@@ -1,3 +1,11 @@
-from .deep_conf_controller import DeepConfOfflineController, DeepConfMajorityVoteController, DeepConfOnlineController, AdaptiveMajorityVoteController
+from .deep_conf_controller import (DeepConfOfflineController,
+                                   DeepConfOfflineMajorityVoteController,
+                                   DeepConfOnlineController,
+                                   DeepConfOnlineMajorityVoteController)
 
-__all__ = ["DeepConfOfflineController", "DeepConfMajorityVoteController", "DeepConfOnlineController", "AdaptiveMajorityVoteController"]
+__all__ = [
+    "DeepConfOfflineController",
+    "DeepConfOnlineController",
+    "DeepConfOfflineMajorityVoteController",
+    "DeepConfOnlineMajorityVoteController",
+]

--- a/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
@@ -1,0 +1,119 @@
+import copy
+from enum import Enum
+from dataclasses import dataclass, field
+from typing import List, Mapping
+from collections import deque
+
+from tensorrt_llm.scaffolding import Controller, NativeGenerationController, MajorityVoteController,ParallelProcess, Task
+from tensorrt_llm.scaffolding.contrib.AsyncGeneration import StreamGenerationTask
+
+@dataclass
+class ConfidenceInfo:
+    conf_grouped: float
+    conf_list: list[float]
+    conf_group_list: deque[float]
+    conf_group_size: int
+    conf_threshold: float
+
+def update_confidence_info(confidence_info: ConfidenceInfo, token_dict: Mapping[int, 'Logprob'], token_id: int):
+    if len(token_dict) > 1:
+        sum = 0.0
+        for logprob_token_id, logprob in token_dict.items():
+            if logprob_token_id != token_id:
+                sum += logprob.logprob
+        new_conf = -sum / (len(token_dict) - 1)
+    else:
+        new_conf = 0.0
+
+    confidence_info.conf_list.append(new_conf)
+
+    if len(confidence_info.conf_group_list) < confidence_info.conf_group_size:
+        confidence_info.conf_grouped += new_conf
+    else:
+        confidence_info.conf_grouped -= confidence_info.conf_group_list.popleft()
+        confidence_info.conf_grouped += new_conf
+
+
+class DeepConfOfflineController(NativeGenerationController):
+
+    def __init__(self, conf_group_size: int, conf_threshold: float, sampling_params: dict = None, streaming: bool = False):
+        super().__init__(sampling_params, streaming)
+        self.confidence_info = ConfidenceInfo(conf_grouped=0.0, conf_list=[], conf_group_list=deque([]), conf_group_size=conf_group_size, conf_threshold=conf_threshold)
+
+    def process(self, tasks: List[Task], **kwargs):
+        yield from super().process(tasks, **kwargs)
+        assert (len(tasks) == 1, "DeepConfOfflineController only supports one task")
+        for logprobs_dict, token_id in zip(tasks[0].logprobs, tasks[0].output_tokens):
+            update_confidence_info(self.confidence_info, logprobs_dict, token_id)
+        tasks[0].costimized_result_fields['confidence_info'] = self.confidence_info
+
+
+class DeepConfMajorityVoteController(MajorityVoteController):
+    
+    # TODO: implement majority vote
+    # ConfidenceInfo is on costimized_result_fields['confidence_info'] of each task
+    def majority_vote(self, candidates_tasks: List[Task], **kwargs) -> Tuple[int, str]:
+        pass
+
+
+class DeepConfOnlineController(Controller):
+    def __init__(self, conf_group_size: int, conf_threshold: float):
+        super().__init__()
+        self.confidence_info = ConfidenceInfo(conf_grouped=0.0, conf_list=[], conf_group_list=deque([]), conf_group_size=conf_group_size, conf_threshold=conf_threshold)
+
+    def clone(self):
+        return DeepThinkOnlineController(self.conf_group_size, self.conf_threshold)
+    
+    def process(self, tasks: List[Task], **kwargs):
+        assert (len(tasks) == 1, "DeepThinkOnlineController only supports one task")
+        online_task = StreamGenerationTask.create_from_generation_task(tasks[0])
+        online_task.streaming_step = self.conf_group_size
+        last_step_index = 0
+        while online_task.end_flag == False:
+            yield [online_task]
+            for i in range(last_step_index, len(online_task.output_tokens)):
+                logprobs_dict, token_id = online_task.logprobs[i], online_task.output_tokens[i]
+                update_confidence_info(self.confidence_info, logprobs_dict, token_id)
+            if self.should_stop(online_task.confidence_info):
+                online_task.cancel_flag = True
+                yield [online_task]
+                break
+            last_step_index = len(online_task.output_tokens)
+        tasks[0].costimized_result_fields['confidence_info'] = self.confidence_info
+
+
+class AdaptiveMajorityVoteController(Controller):
+    def __init__(self, generation_controller: Controller, sample_num_per_round: int, max_sample_num: float):
+        super().__init__()
+        self.generation_controller = generation_controller
+        self.sample_num_per_round = sample_num_per_round
+        self.max_sample_num = max_sample_num
+
+    def clone(self):
+        return AdaptiveMajorityVoteController(self.generation_controller.clone(), self.sample_num, self.max_sample_num)
+    
+    def process(self, tasks: List[Task], **kwargs):
+        candidates = []
+        should_continue = True
+        sample_next_round = self.sample_num_per_round
+        while len(candidates) < self.max_sample_num and should_continue:
+            sample_num = sample_next_round
+            generation_controllers = [
+                self.generation_controller.clone() for _ in range()
+            ]
+            tasks_list = [copy.deepcopy(tasks) for _ in range(sample_num)]
+            generation_kwargs_list = [
+                copy.deepcopy(kwargs) for _ in range(sample_num)
+            ]
+            yield ParallelProcess(generation_controllers, tasks_list, generation_kwargs_list)
+            
+            should_continue, sample_next_round = self.next_round_judge(candidates, tasks_list)
+            candidates.extend(tasks_list)
+
+        return self.majority_vote(candidates, **kwargs)
+
+    def next_round_judge(self, candidates: List[Task], tasks_list: List[Task]) -> Tuple[bool, int]:
+        pass
+
+    def majority_vote(self, candidates: List[Task], **kwargs) -> Tuple[int, str]:
+        pass

--- a/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
@@ -1,243 +1,71 @@
 import copy
-import random
-from collections import Counter, deque
-from dataclasses import dataclass, field
-from enum import Enum
-from itertools import chain
-from typing import List, Mapping, Optional
+from typing import List, Optional
 
 import numpy as np
 
-from tensorrt_llm.scaffolding import (Controller, NativeGenerationController,
-                                      ParallelProcess, StreamGenerationTask,
-                                      Task, extract_answer_from_boxed)
+from tensorrt_llm.scaffolding import (Controller, ParallelProcess,
+                                      StreamGenerationTask, Task)
+
+from .deep_conf_utils import ConfidenceInfo, majority_vote
 
 
-@dataclass
-class ConfidenceInfo:
-    conf_grouped: float = 0.0
-    conf_group_size: int = 128
-    conf_threshold: float = 0.0
-    conf_list: list[float] = field(default_factory=list)
-    conf_group_list: deque[float] = field(default_factory=deque)
-    avg_conf_group_list: list[float] = field(default_factory=list)
+class DeepConfOfflineController(Controller):
 
-    def get_min_conf_grouped(self):
-        if len(self.avg_conf_group_list) == 0:
-            print(
-                f"Warning: no valid conf group yet, maybe you should decrease conf_group_size"
-            )
-            return self.conf_threshold
-        return min(self.avg_conf_group_list)
-
-    def should_stop(self):
-        return self.avg_conf_group_list[-1] < self.conf_threshold if len(
-            self.conf_list) >= self.conf_group_size else False
-
-    def get_statistics(self,
-                       tail_tokens: int = 2048,
-                       bottom_percent: float = 0.1):
-        # global mean confidence
-        self.mean_conf = np.mean(self.conf_list)
-
-        # tail mean confidence
-        tail_conf_list = self.conf_list[-tail_tokens:] if len(
-            self.conf_list) > tail_tokens else self.conf_list
-        self.tail_mean_conf = np.mean(tail_conf_list)
-
-        # bottom window mean confidence and min window confidence
-        if len(self.avg_conf_group_list) == 0:
-            self.bottom_window_mean_conf = np.mean(self.conf_list)
-            self.min_window_conf = self.bottom_window_mean_conf
-        else:
-            num_bottom = max(
-                1, int(len(self.avg_conf_group_list) * bottom_percent))
-            if num_bottom == 1:
-                self.bottom_window_mean_conf = np.min(self.avg_conf_group_list)
-            else:
-                self.bottom_window_mean_conf = np.mean(
-                    np.partition(self.avg_conf_group_list,
-                                 num_bottom - 1)[:num_bottom])
-            self.min_window_conf = np.min(self.avg_conf_group_list)
-
-    def update_confidence_info(self, token_dict: Mapping[int, 'Logprob'],
-                               token_id: int):
-        mean_logprob = np.mean(
-            [logprob_obj.logprob for logprob_obj in token_dict.values()])
-        new_conf = round(-mean_logprob, 3)
-        self.conf_list.append(new_conf)
-        self.conf_grouped += new_conf
-        self.conf_group_list.append(new_conf)
-        if len(self.conf_group_list) > self.conf_group_size:
-            self.conf_grouped -= self.conf_group_list.popleft()
-        if len(self.conf_group_list) == self.conf_group_size:
-            self.avg_conf_group_list.append(self.conf_grouped /
-                                            self.conf_group_size)
-
-
-def basic_majority_vote(tasks: List[Task], **kwargs) -> Task:
-    answers = kwargs['answers']
-    majority_answer = Counter(answers).most_common(1)[0][0]
-    return tasks[answers.index(majority_answer)]
-
-
-def weighted_majority_vote(type: str, filter_top_percent: float = 1.0):
-
-    def impl(tasks: List[Task], **kwargs) -> Task:
-        answers = kwargs['answers']
-        if type == 'mean_confidence_weighted':
-            confidences = kwargs['mean_confidences']
-        elif type == 'tail_confidence_weighted':
-            confidences = kwargs['tail_confidences']
-        elif type == 'bottom_window_weighted':
-            confidences = kwargs['bottom_window_confidences']
-        elif type == 'min_window_weighted':
-            confidences = kwargs['min_window_confidences']
-        else:
-            raise ValueError(f"Invalid type: {type}")
-
-        if filter_top_percent < 1:
-            num_keep = max(1, int(len(confidences) * filter_top_percent))
-            sorted_indices = np.argsort(confidences)[::-1]
-            save_indices = sorted_indices[:num_keep].tolist()
-
-            tasks = [tasks[i] for i in save_indices]
-            answers = [answers[i] for i in save_indices]
-            confidences = [confidences[i] for i in save_indices]
-
-        print(f"{type=} {filter_top_percent=} has {len(tasks)} valid tasks",
-              flush=True)
-
-        answer_to_weights = {}
-        for answer, confidence in zip(answers, confidences):
-            answer_to_weights[answer] = answer_to_weights.get(answer,
-                                                              0.0) + confidence
-        majority_answer = max(answer_to_weights, key=answer_to_weights.get)
-        return tasks[answers.index(majority_answer)]
-
-    return impl
-
-
-VOTE_POLICY_IMPL = {
-    'majority':
-    basic_majority_vote,
-    "mean_confidence_weighted":
-    weighted_majority_vote('mean_confidence_weighted'),
-    "tail_confidence_weighted":
-    weighted_majority_vote('tail_confidence_weighted'),
-    "bottom_window_weighted":
-    weighted_majority_vote('bottom_window_weighted'),
-    "min_window_weighted":
-    weighted_majority_vote('min_window_weighted'),
-    "top10_tail_filtered":
-    weighted_majority_vote('tail_confidence_weighted', filter_top_percent=0.1),
-    "top10_bottom_window_filtered":
-    weighted_majority_vote('bottom_window_weighted', filter_top_percent=0.1)
-}
-
-
-def vote(tasks: List[Task]):
-    for task in tasks:
-        task.costimized_result_fields[
-            'extracted_answer'] = extract_answer_from_boxed(task.output_str)
-        task.costimized_result_fields['confidence_info'].get_statistics()
-    valid_tasks = [
-        task for task in tasks
-        if task.costimized_result_fields['extracted_answer']
-    ]
-    if len(valid_tasks) == 0:
-        print(
-            "Warning: No valid tasks, maybe you should increase max_output_len, a random task will be returned"
-        )
-        return {
-            policy_name: random.choice(tasks)
-            for policy_name, policy_impl in VOTE_POLICY_IMPL.items()
-        }
-
-    answers = [
-        task.costimized_result_fields['extracted_answer']
-        for task in valid_tasks
-    ]
-    confidences = [
-        task.costimized_result_fields['confidence_info'] for task in valid_tasks
-    ]
-    mean_confidences = [conf.mean_conf for conf in confidences]
-    tail_confidences = [conf.tail_mean_conf for conf in confidences]
-    bottom_window_confidences = [
-        conf.bottom_window_mean_conf for conf in confidences
-    ]
-    min_window_confidences = [conf.min_window_conf for conf in confidences]
-
-    return {
-        policy_name:
-        policy_impl(valid_tasks,
-                    answers=answers,
-                    mean_confidences=mean_confidences,
-                    tail_confidences=tail_confidences,
-                    bottom_window_confidences=bottom_window_confidences,
-                    min_window_confidences=min_window_confidences)
-        for policy_name, policy_impl in VOTE_POLICY_IMPL.items()
-    }
-
-
-class DeepConfOfflineController(NativeGenerationController):
-
-    def __init__(self,
-                 conf_group_size: int,
-                 conf_threshold: float,
-                 logprobs_topk: int = 20,
-                 sampling_params: dict = None,
-                 streaming: bool = False,
-                 **kwargs):
-        super().__init__(sampling_params, streaming)
-        self.logprobs_topk = logprobs_topk
+    def __init__(self, generation_controller: Controller, conf_group_size: int,
+                 conf_threshold: float, **kwargs):
+        super().__init__()
+        self.generation_controller = generation_controller
+        self.conf_group_size = conf_group_size
+        self.conf_threshold = conf_threshold
         self.confidence_info = ConfidenceInfo(conf_group_size=conf_group_size,
                                               conf_threshold=conf_threshold)
+
+    def clone(self):
+        return DeepConfOfflineController(
+            generation_controller=self.generation_controller.clone(),
+            conf_group_size=self.conf_group_size,
+            conf_threshold=self.conf_threshold,
+        )
 
     def process(self, tasks: List[Task], **kwargs):
         assert len(
             tasks) == 1, "DeepConfOfflineController only supports one task"
-        yield from super().process(tasks, **kwargs)
+
+        yield from self.generation_controller.process(tasks, **kwargs)
+
         for logprobs_dict, token_id in zip(tasks[0].logprobs,
                                            tasks[0].output_tokens):
             self.confidence_info.update_confidence_info(logprobs_dict, token_id)
         tasks[0].costimized_result_fields[
             'confidence_info'] = self.confidence_info
+
         print(f"end process, generated {len(tasks[0].output_tokens)} tokens",
               flush=True)
 
 
 class DeepConfOfflineMajorityVoteController(Controller):
 
-    class WorkerTag(Enum):
-        GENERATION = "generation"
-
     def __init__(self,
+                 generation_controller: Controller,
                  sample_num: int,
                  conf_group_size: int,
                  conf_threshold: float,
                  vote_policy: str = 'majority',
-                 logprobs_topk: int = 20,
-                 sampling_params: dict = None,
                  **kwargs):
         super().__init__()
+        self.generation_controller = generation_controller
         self.sample_num = sample_num
         self.conf_group_size = conf_group_size
         self.conf_threshold = conf_threshold
         self.vote_policy = vote_policy
-        self.logprobs_topk = logprobs_topk
-        self.sampling_params = sampling_params
-
-        self.generation_controller = DeepConfOfflineController(
-            conf_group_size=conf_group_size,
-            conf_threshold=conf_threshold,
-            logprobs_topk=logprobs_topk,
-            sampling_params=sampling_params)
 
     def clone(self):
         return DeepConfOfflineMajorityVoteController(
-            self.sample_num, self.conf_group_size, self.conf_threshold,
-            self.vote_policy, self.logprobs_topk, self.sampling_params)
+            generation_controller=self.generation_controller.clone(),
+            sample_num=self.sample_num,
+            conf_group_size=self.conf_group_size,
+            conf_threshold=self.conf_threshold,
+            vote_policy=self.vote_policy)
 
     def process(self, tasks: List[Task], **kwargs):
         assert len(
@@ -253,42 +81,40 @@ class DeepConfOfflineMajorityVoteController(Controller):
         yield ParallelProcess(generation_controllers, tasks_list,
                               generation_kwargs_list)
 
-        task_list = [ttasks[0] for ttasks in tasks_list]
-        tasks[0].result = vote(task_list)[self.vote_policy].result
+        tasks[0].result = majority_vote(tasks_list,
+                                        vote_policy=self.vote_policy).result
 
 
 class DeepConfOnlineController(Controller):
 
-    class WorkerTag(Enum):
-        GENERATION = "generation"
-
-    def __init__(self,
-                 conf_group_size: int,
-                 conf_threshold: float,
-                 logprobs_topk: int = 20,
-                 sampling_params: dict = None):
+    def __init__(self, generation_controller: Controller, conf_group_size: int,
+                 conf_threshold: float, **kwargs):
         super().__init__()
-        self.sampling_params = sampling_params
-        self.logprobs_topk = logprobs_topk
+        self.generation_controller = generation_controller
+        self.conf_group_size = conf_group_size
+        self.conf_threshold = conf_threshold
         self.confidence_info = ConfidenceInfo(conf_group_size=conf_group_size,
                                               conf_threshold=conf_threshold)
+
+    def clone(self):
+        return DeepConfOnlineController(
+            generation_controller=self.generation_controller.clone(),
+            conf_group_size=self.conf_group_size,
+            conf_threshold=self.conf_threshold,
+        )
 
     def process(self, tasks: List[Task], **kwargs):
         print(f"begin online controller", flush=True)
         assert len(
             tasks) == 1, "DeepThinkOnlineController only supports one task"
-        online_task = StreamGenerationTask.create_from_generation_task(tasks[0])
-        online_task.streaming_step = self.confidence_info.conf_group_size
-        online_task.worker_tag = self.WorkerTag.GENERATION
-
-        for key, value in self.sampling_params.items():
-            if getattr(online_task, key) is None:
-                setattr(online_task, key, value)
+        online_task = StreamGenerationTask.create_from_generation_task(
+            tasks[0], streaming_step=self.confidence_info.conf_group_size)
 
         last_step_index = 0
         while online_task.end_flag == False:
-            yield [online_task]
-            for i in range(last_step_index, len(online_task.output_tokens)):
+            generated_token_num = len(
+                online_task.output_tokens) if online_task.output_tokens else 0
+            for i in range(last_step_index, generated_token_num):
                 logprobs_dict, token_id = online_task.logprobs[
                     i], online_task.output_tokens[i]
                 self.confidence_info.update_confidence_info(
@@ -298,12 +124,17 @@ class DeepConfOnlineController(Controller):
                         f"early stop, {self.confidence_info.avg_conf_group_list[-1]} < {self.confidence_info.conf_threshold}, generated {len(self.confidence_info.conf_list)} tokens",
                         flush=True)
                     online_task.cancel_flag = True
-                    yield [online_task]
                     break
-            print(
-                f"continue to generate, generated {len(online_task.output_tokens)} tokens",
-                flush=True)
-            last_step_index = len(online_task.output_tokens)
+
+            if not online_task.cancel_flag:
+                print(
+                    f"continue to generate, has generated {generated_token_num} tokens",
+                    flush=True)
+
+            last_step_index = generated_token_num
+            yield from self.generation_controller.process([online_task],
+                                                          **kwargs)
+
         tasks[0].result = online_task.result
         tasks[0].costimized_result_fields[
             'confidence_info'] = self.confidence_info
@@ -314,20 +145,19 @@ class DeepConfOnlineController(Controller):
 
 class DeepConfOnlineMajorityVoteController(Controller):
 
-    class WorkerTag(Enum):
-        GENERATION = "generation"
-
     def __init__(self,
+                 warmup_generation_controller: Controller,
+                 final_generation_controller: Controller,
                  sample_num: int,
                  conf_group_size: int,
                  conf_threshold: float,
                  vote_policy: str = 'majority',
                  warmup_sample_num: int = 5,
                  confidence_percentile: int = 90,
-                 logprobs_topk: int = 20,
-                 sampling_params: dict = None,
                  **kwargs):
         super().__init__()
+        self.warmup_generation_controller = warmup_generation_controller
+        self.final_generation_controller = final_generation_controller
         self.sample_num = sample_num
         self.warmup_sample_num = warmup_sample_num
         assert sample_num >= warmup_sample_num, f"{sample_num=} must be greater than {warmup_sample_num=}"
@@ -336,78 +166,58 @@ class DeepConfOnlineMajorityVoteController(Controller):
         self.conf_threshold = conf_threshold
         self.confidence_percentile = confidence_percentile
         self.vote_policy = vote_policy
-        self.logprobs_topk = logprobs_topk
-        self.sampling_params = sampling_params
-
-        self.warmup_generation_controller = DeepConfOfflineController(
-            conf_group_size=self.conf_group_size,
-            conf_threshold=self.conf_threshold,
-            logprobs_topk=self.logprobs_topk,
-            sampling_params=self.sampling_params)
-        self.final_generation_controller = DeepConfOnlineController(
-            conf_group_size=self.conf_group_size,
-            conf_threshold=self.conf_threshold,
-            logprobs_topk=self.logprobs_topk,
-            sampling_params=self.sampling_params)
 
     def clone(self):
         return DeepConfOnlineMajorityVoteController(
+            warmup_generation_controller=self.warmup_generation_controller.
+            clone(),
+            final_generation_controller=self.final_generation_controller.clone(
+            ),
             sample_num=self.sample_num,
             conf_group_size=self.conf_group_size,
             conf_threshold=self.conf_threshold,
             vote_policy=self.vote_policy,
             warmup_sample_num=self.warmup_sample_num,
             confidence_percentile=self.confidence_percentile,
-            logprobs_topk=self.logprobs_topk,
-            sampling_params=self.sampling_params)
+        )
 
     def process(self, tasks: List[Task], **kwargs):
         assert len(
             tasks
         ) == 1, "DeepConfOnlineMajorityVoteController only supports one task"
         # warm up to get conf_threshold
-        if self.warmup_sample_num > 0:
-            print(f"begin warmup", flush=True)
-            warmup_tasks_list = yield from self.parallel_generate(tasks,
-                                                                  warmup=True,
-                                                                  **kwargs)
-            print(f"end warmup", flush=True)
+        print(f"begin warmup", flush=True)
+        warmup_tasks_list = yield from self.parallel_generate(
+            tasks=tasks,
+            sample_num=self.warmup_sample_num,
+            generation_controller=self.warmup_generation_controller,
+            **kwargs)
+        print(f"end warmup", flush=True)
 
-            min_confs = [
-                tasks[0].costimized_result_fields['confidence_info'].
-                get_min_conf_grouped() for tasks in warmup_tasks_list
-            ]
-            conf_bar = float(
-                np.percentile(min_confs, 100 - self.confidence_percentile))
-        else:
-            warmup_tasks_list = []
-            conf_bar = self.conf_threshold
+        conf_bar = self.get_conf_bar(warmup_tasks_list)
         print(f"conf_bar={conf_bar}", flush=True)
 
-        if self.final_sample_num > 0:
-            print(f"begin final", flush=True)
-            final_tasks_list = yield from self.parallel_generate(
-                tasks, warmup=False, conf_bar=conf_bar, **kwargs)
-            print(f"end final", flush=True)
-        else:
-            final_tasks_list = []
+        print(f"begin final", flush=True)
+        final_tasks_list = yield from self.parallel_generate(
+            tasks=tasks,
+            sample_num=self.final_sample_num,
+            generation_controller=self.final_generation_controller,
+            conf_bar=conf_bar,
+            **kwargs)
+        print(f"end final", flush=True)
 
-        finished_task_list = [
-            finished_tasks[0]
-            for finished_tasks in chain(warmup_tasks_list, final_tasks_list)
-        ]
-        print(f"len(finished_task_list)={len(finished_task_list)}", flush=True)
-        tasks[0].result = vote(finished_task_list)[self.vote_policy].result
+        tasks[0].result = majority_vote(warmup_tasks_list + final_tasks_list,
+                                        vote_policy=self.vote_policy).result
         print(f"end vote", flush=True)
 
     def parallel_generate(self,
                           tasks: List[Task],
-                          warmup: bool,
+                          sample_num,
+                          generation_controller,
                           conf_bar: Optional[float] = None,
                           **kwargs):
-        # warmup will not stop early
-        generation_controller = self.warmup_generation_controller if warmup else self.final_generation_controller
-        sample_num = self.warmup_sample_num if warmup else self.final_sample_num
+        if sample_num == 0:
+            return []
 
         generation_controllers = [
             generation_controller.clone() for _ in range(sample_num)
@@ -423,3 +233,13 @@ class DeepConfOnlineMajorityVoteController(Controller):
                               generation_kwargs_list)
 
         return tasks_list
+
+    def get_conf_bar(self, tasks_list: List[List[Task]]) -> float:
+        min_confs = [
+            tasks[0].costimized_result_fields['confidence_info'].
+            get_min_conf_grouped() for tasks in tasks_list
+        ]
+        if len(min_confs) > 0:
+            return float(
+                np.percentile(min_confs, 100 - self.confidence_percentile))
+        return self.conf_threshold

--- a/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
@@ -1,9 +1,12 @@
 import copy
 import random
 from collections import Counter, deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Mapping, Tuple
+from itertools import chain
+from typing import List, Mapping, Optional
+
+import numpy as np
 
 from tensorrt_llm.scaffolding import (Controller, NativeGenerationController,
                                       ParallelProcess, StreamGenerationTask,
@@ -12,35 +15,124 @@ from tensorrt_llm.scaffolding import (Controller, NativeGenerationController,
 
 @dataclass
 class ConfidenceInfo:
-    conf_grouped: float
-    conf_list: list[float]
-    conf_group_list: deque[float]
-    conf_group_size: int
-    conf_threshold: float
+    conf_grouped: float = 0.0
+    conf_group_size: int = 128
+    conf_threshold: float = 0.0
+    conf_list: list[float] = field(default_factory=list)
+    conf_group_list: deque[float] = field(default_factory=deque)
+    avg_conf_group_list: list[float] = field(default_factory=list)
+
+    def get_min_conf_grouped(self):
+        if len(self.avg_conf_group_list) == 0:
+            print(
+                f"Warning: no valid conf group yet, maybe you should decrease conf_group_size"
+            )
+            return self.conf_threshold
+        return min(self.avg_conf_group_list)
+
+    def should_stop(self):
+        return self.avg_conf_group_list[-1] < self.conf_threshold if len(
+            self.conf_list) >= self.conf_group_size else False
+
+    def get_statistics(self,
+                       tail_tokens: int = 2048,
+                       bottom_percent: float = 0.1):
+        # global mean confidence
+        self.mean_conf = np.mean(self.conf_list)
+
+        # tail mean confidence
+        tail_conf_list = self.conf_list[-tail_tokens:] if len(
+            self.conf_list) > tail_tokens else self.conf_list
+        self.tail_mean_conf = np.mean(tail_conf_list)
+
+        # bottom window mean confidence and min window confidence
+        if len(self.avg_conf_group_list) == 0:
+            self.bottom_window_mean_conf = np.mean(self.conf_list)
+            self.min_window_conf = self.bottom_window_mean_conf
+        else:
+            num_bottom = max(
+                1, int(len(self.avg_conf_group_list) * bottom_percent))
+            if num_bottom == 1:
+                self.bottom_window_mean_conf = np.min(self.avg_conf_group_list)
+            else:
+                self.bottom_window_mean_conf = np.mean(
+                    np.partition(self.avg_conf_group_list,
+                                 num_bottom - 1)[:num_bottom])
+            self.min_window_conf = np.min(self.avg_conf_group_list)
+
+    def update_confidence_info(self, token_dict: Mapping[int, 'Logprob'],
+                               token_id: int):
+        mean_logprob = np.mean(
+            [logprob_obj.logprob for logprob_obj in token_dict.values()])
+        new_conf = round(-mean_logprob, 3)
+        self.conf_list.append(new_conf)
+        self.conf_grouped += new_conf
+        self.conf_group_list.append(new_conf)
+        if len(self.conf_group_list) > self.conf_group_size:
+            self.conf_grouped -= self.conf_group_list.popleft()
+        if len(self.conf_group_list) == self.conf_group_size:
+            self.avg_conf_group_list.append(self.conf_grouped /
+                                            self.conf_group_size)
 
 
-def update_confidence_info(confidence_info: ConfidenceInfo,
-                           token_dict: Mapping[int, 'Logprob'], token_id: int):
-    new_conf = -sum(logprob_obj.logprob
-                    for logprob_obj in token_dict.values()) / len(token_dict)
-    confidence_info.conf_list.append(new_conf)
-    confidence_info.conf_group_list.append(new_conf)
-    confidence_info.conf_grouped += new_conf
-    if len(confidence_info.conf_group_list) > confidence_info.conf_group_size:
-        confidence_info.conf_grouped -= confidence_info.conf_group_list.popleft(
-        )
-
-
-def basic_majority_vote(tasks: List[Task]) -> Task:
-    answers = [
-        task.costimized_result_fields['extracted_answer'] for task in tasks
-    ]
+def basic_majority_vote(tasks: List[Task], **kwargs) -> Task:
+    answers = kwargs['answers']
     majority_answer = Counter(answers).most_common(1)[0][0]
     return tasks[answers.index(majority_answer)]
 
 
+def weighted_majority_vote(type: str, filter_top_percent: float = 1.0):
+
+    def impl(tasks: List[Task], **kwargs) -> Task:
+        answers = kwargs['answers']
+        if type == 'mean_confidence_weighted':
+            confidences = kwargs['mean_confidences']
+        elif type == 'tail_confidence_weighted':
+            confidences = kwargs['tail_confidences']
+        elif type == 'bottom_window_weighted':
+            confidences = kwargs['bottom_window_confidences']
+        elif type == 'min_window_weighted':
+            confidences = kwargs['min_window_confidences']
+        else:
+            raise ValueError(f"Invalid type: {type}")
+
+        if filter_top_percent < 1:
+            num_keep = max(1, int(len(confidences) * filter_top_percent))
+            sorted_indices = np.argsort(confidences)[::-1]
+            save_indices = sorted_indices[:num_keep].tolist()
+
+            tasks = [tasks[i] for i in save_indices]
+            answers = [answers[i] for i in save_indices]
+            confidences = [confidences[i] for i in save_indices]
+
+        print(f"{type=} {filter_top_percent=} has {len(tasks)} valid tasks",
+              flush=True)
+
+        answer_to_weights = {}
+        for answer, confidence in zip(answers, confidences):
+            answer_to_weights[answer] = answer_to_weights.get(answer,
+                                                              0.0) + confidence
+        majority_answer = max(answer_to_weights, key=answer_to_weights.get)
+        return tasks[answers.index(majority_answer)]
+
+    return impl
+
+
 VOTE_POLICY_IMPL = {
-    'majority': basic_majority_vote,
+    'majority':
+    basic_majority_vote,
+    "mean_confidence_weighted":
+    weighted_majority_vote('mean_confidence_weighted'),
+    "tail_confidence_weighted":
+    weighted_majority_vote('tail_confidence_weighted'),
+    "bottom_window_weighted":
+    weighted_majority_vote('bottom_window_weighted'),
+    "min_window_weighted":
+    weighted_majority_vote('min_window_weighted'),
+    "top10_tail_filtered":
+    weighted_majority_vote('tail_confidence_weighted', filter_top_percent=0.1),
+    "top10_bottom_window_filtered":
+    weighted_majority_vote('bottom_window_weighted', filter_top_percent=0.1)
 }
 
 
@@ -48,19 +140,42 @@ def vote(tasks: List[Task]):
     for task in tasks:
         task.costimized_result_fields[
             'extracted_answer'] = extract_answer_from_boxed(task.output_str)
+        task.costimized_result_fields['confidence_info'].get_statistics()
     valid_tasks = [
         task for task in tasks
         if task.costimized_result_fields['extracted_answer']
     ]
-    random_return = False
     if len(valid_tasks) == 0:
         print(
-            "No valid tasks, maybe you should increase max_output_len, a random task will be returned"
+            "Warning: No valid tasks, maybe you should increase max_output_len, a random task will be returned"
         )
-        random_return = True
+        return {
+            policy_name: random.choice(tasks)
+            for policy_name, policy_impl in VOTE_POLICY_IMPL.items()
+        }
+
+    answers = [
+        task.costimized_result_fields['extracted_answer']
+        for task in valid_tasks
+    ]
+    confidences = [
+        task.costimized_result_fields['confidence_info'] for task in valid_tasks
+    ]
+    mean_confidences = [conf.mean_conf for conf in confidences]
+    tail_confidences = [conf.tail_mean_conf for conf in confidences]
+    bottom_window_confidences = [
+        conf.bottom_window_mean_conf for conf in confidences
+    ]
+    min_window_confidences = [conf.min_window_conf for conf in confidences]
+
     return {
         policy_name:
-        policy_impl(valid_tasks) if not random_return else random.choice(tasks)
+        policy_impl(valid_tasks,
+                    answers=answers,
+                    mean_confidences=mean_confidences,
+                    tail_confidences=tail_confidences,
+                    bottom_window_confidences=bottom_window_confidences,
+                    min_window_confidences=min_window_confidences)
         for policy_name, policy_impl in VOTE_POLICY_IMPL.items()
     }
 
@@ -72,13 +187,11 @@ class DeepConfOfflineController(NativeGenerationController):
                  conf_threshold: float,
                  logprobs_topk: int = 20,
                  sampling_params: dict = None,
-                 streaming: bool = False):
+                 streaming: bool = False,
+                 **kwargs):
         super().__init__(sampling_params, streaming)
         self.logprobs_topk = logprobs_topk
-        self.confidence_info = ConfidenceInfo(conf_grouped=0.0,
-                                              conf_list=[],
-                                              conf_group_list=deque([]),
-                                              conf_group_size=conf_group_size,
+        self.confidence_info = ConfidenceInfo(conf_group_size=conf_group_size,
                                               conf_threshold=conf_threshold)
 
     def process(self, tasks: List[Task], **kwargs):
@@ -87,10 +200,11 @@ class DeepConfOfflineController(NativeGenerationController):
         yield from super().process(tasks, **kwargs)
         for logprobs_dict, token_id in zip(tasks[0].logprobs,
                                            tasks[0].output_tokens):
-            update_confidence_info(self.confidence_info, logprobs_dict,
-                                   token_id)
+            self.confidence_info.update_confidence_info(logprobs_dict, token_id)
         tasks[0].costimized_result_fields[
             'confidence_info'] = self.confidence_info
+        print(f"end process, generated {len(tasks[0].output_tokens)} tokens",
+              flush=True)
 
 
 class DeepConfOfflineMajorityVoteController(Controller):
@@ -99,34 +213,36 @@ class DeepConfOfflineMajorityVoteController(Controller):
         GENERATION = "generation"
 
     def __init__(self,
-                 generation_controller: Controller,
                  sample_num: int,
                  conf_group_size: int,
                  conf_threshold: float,
-                 vote_policy: str = 'majority'):
+                 vote_policy: str = 'majority',
+                 logprobs_topk: int = 20,
+                 sampling_params: dict = None,
+                 **kwargs):
         super().__init__()
-        self.generation_controller = generation_controller
         self.sample_num = sample_num
         self.conf_group_size = conf_group_size
         self.conf_threshold = conf_threshold
-        self.confidence_info = [
-            ConfidenceInfo(conf_grouped=0.0,
-                           conf_list=[],
-                           conf_group_list=deque([]),
-                           conf_group_size=conf_group_size,
-                           conf_threshold=conf_threshold)
-            for _ in range(self.sample_num)
-        ]
         self.vote_policy = vote_policy
+        self.logprobs_topk = logprobs_topk
+        self.sampling_params = sampling_params
+
+        self.generation_controller = DeepConfOfflineController(
+            conf_group_size=conf_group_size,
+            conf_threshold=conf_threshold,
+            logprobs_topk=logprobs_topk,
+            sampling_params=sampling_params)
 
     def clone(self):
         return DeepConfOfflineMajorityVoteController(
-            self.generation_controller.clone(), self.sample_num,
-            self.conf_group_size, self.conf_threshold, self.vote_policy)
+            self.sample_num, self.conf_group_size, self.conf_threshold,
+            self.vote_policy, self.logprobs_topk, self.sampling_params)
 
     def process(self, tasks: List[Task], **kwargs):
         assert len(
             tasks) == 1, "DeepConfMajorityVoteController only supports one task"
+
         generation_controllers = [
             self.generation_controller.clone() for _ in range(self.sample_num)
         ]
@@ -137,14 +253,7 @@ class DeepConfOfflineMajorityVoteController(Controller):
         yield ParallelProcess(generation_controllers, tasks_list,
                               generation_kwargs_list)
 
-        task_list = [tasks[0] for tasks in tasks_list]
-        for i, task in enumerate(task_list):
-            for logprobs_dict, token_id in zip(task.logprobs,
-                                               task.output_tokens):
-                update_confidence_info(self.confidence_info[i], logprobs_dict,
-                                       token_id)
-            task.costimized_result_fields[
-                'confidence_info'] = self.confidence_info[i]
+        task_list = [ttasks[0] for ttasks in tasks_list]
         tasks[0].result = vote(task_list)[self.vote_policy].result
 
 
@@ -161,13 +270,11 @@ class DeepConfOnlineController(Controller):
         super().__init__()
         self.sampling_params = sampling_params
         self.logprobs_topk = logprobs_topk
-        self.confidence_info = ConfidenceInfo(conf_grouped=0.0,
-                                              conf_list=[],
-                                              conf_group_list=deque([]),
-                                              conf_group_size=conf_group_size,
+        self.confidence_info = ConfidenceInfo(conf_group_size=conf_group_size,
                                               conf_threshold=conf_threshold)
 
     def process(self, tasks: List[Task], **kwargs):
+        print(f"begin online controller", flush=True)
         assert len(
             tasks) == 1, "DeepThinkOnlineController only supports one task"
         online_task = StreamGenerationTask.create_from_generation_task(tasks[0])
@@ -184,67 +291,135 @@ class DeepConfOnlineController(Controller):
             for i in range(last_step_index, len(online_task.output_tokens)):
                 logprobs_dict, token_id = online_task.logprobs[
                     i], online_task.output_tokens[i]
-                update_confidence_info(self.confidence_info, logprobs_dict,
-                                       token_id)
-            if self.should_stop(self.confidence_info):
-                online_task.cancel_flag = True
-                yield [online_task]
-                break
+                self.confidence_info.update_confidence_info(
+                    logprobs_dict, token_id)
+                if self.confidence_info.should_stop():
+                    print(
+                        f"early stop, {self.confidence_info.avg_conf_group_list[-1]} < {self.confidence_info.conf_threshold}, generated {len(self.confidence_info.conf_list)} tokens",
+                        flush=True)
+                    online_task.cancel_flag = True
+                    yield [online_task]
+                    break
+            print(
+                f"continue to generate, generated {len(online_task.output_tokens)} tokens",
+                flush=True)
             last_step_index = len(online_task.output_tokens)
         tasks[0].result = online_task.result
         tasks[0].costimized_result_fields[
             'confidence_info'] = self.confidence_info
-
-    # TODO: implement should_stop
-    def should_stop(self, confidence_info: ConfidenceInfo) -> bool:
-        if len(confidence_info.conf_group_list
-               ) >= confidence_info.conf_group_size:
-            avg_conf = confidence_info.conf_grouped / len(
-                confidence_info.conf_group_list)
-            return avg_conf < confidence_info.conf_threshold
-        return False
+        print(
+            f"end online controller, generated {len(online_task.output_tokens)} tokens",
+            flush=True)
 
 
 class DeepConfOnlineMajorityVoteController(Controller):
 
-    def __init__(self, generation_controller: Controller,
-                 sample_num_per_round: int, max_sample_num: float):
+    class WorkerTag(Enum):
+        GENERATION = "generation"
+
+    def __init__(self,
+                 sample_num: int,
+                 conf_group_size: int,
+                 conf_threshold: float,
+                 vote_policy: str = 'majority',
+                 warmup_sample_num: int = 5,
+                 confidence_percentile: int = 90,
+                 logprobs_topk: int = 20,
+                 sampling_params: dict = None,
+                 **kwargs):
         super().__init__()
-        self.generation_controller = generation_controller
-        self.sample_num_per_round = sample_num_per_round
-        self.max_sample_num = max_sample_num
+        self.sample_num = sample_num
+        self.warmup_sample_num = warmup_sample_num
+        assert sample_num >= warmup_sample_num, f"{sample_num=} must be greater than {warmup_sample_num=}"
+        self.final_sample_num = sample_num - warmup_sample_num
+        self.conf_group_size = conf_group_size
+        self.conf_threshold = conf_threshold
+        self.confidence_percentile = confidence_percentile
+        self.vote_policy = vote_policy
+        self.logprobs_topk = logprobs_topk
+        self.sampling_params = sampling_params
+
+        self.warmup_generation_controller = DeepConfOfflineController(
+            conf_group_size=self.conf_group_size,
+            conf_threshold=self.conf_threshold,
+            logprobs_topk=self.logprobs_topk,
+            sampling_params=self.sampling_params)
+        self.final_generation_controller = DeepConfOnlineController(
+            conf_group_size=self.conf_group_size,
+            conf_threshold=self.conf_threshold,
+            logprobs_topk=self.logprobs_topk,
+            sampling_params=self.sampling_params)
 
     def clone(self):
         return DeepConfOnlineMajorityVoteController(
-            self.generation_controller.clone(), self.sample_num,
-            self.max_sample_num)
+            sample_num=self.sample_num,
+            conf_group_size=self.conf_group_size,
+            conf_threshold=self.conf_threshold,
+            vote_policy=self.vote_policy,
+            warmup_sample_num=self.warmup_sample_num,
+            confidence_percentile=self.confidence_percentile,
+            logprobs_topk=self.logprobs_topk,
+            sampling_params=self.sampling_params)
 
     def process(self, tasks: List[Task], **kwargs):
-        candidates = []
-        should_continue = True
-        sample_next_round = self.sample_num_per_round
-        while len(candidates) < self.max_sample_num and should_continue:
-            sample_num = sample_next_round
-            generation_controllers = [
-                self.generation_controller.clone() for _ in range()
+        assert len(
+            tasks
+        ) == 1, "DeepConfOnlineMajorityVoteController only supports one task"
+        # warm up to get conf_threshold
+        if self.warmup_sample_num > 0:
+            print(f"begin warmup", flush=True)
+            warmup_tasks_list = yield from self.parallel_generate(tasks,
+                                                                  warmup=True,
+                                                                  **kwargs)
+            print(f"end warmup", flush=True)
+
+            min_confs = [
+                tasks[0].costimized_result_fields['confidence_info'].
+                get_min_conf_grouped() for tasks in warmup_tasks_list
             ]
-            tasks_list = [copy.deepcopy(tasks) for _ in range(sample_num)]
-            generation_kwargs_list = [
-                copy.deepcopy(kwargs) for _ in range(sample_num)
-            ]
-            yield ParallelProcess(generation_controllers, tasks_list,
-                                  generation_kwargs_list)
+            conf_bar = float(
+                np.percentile(min_confs, 100 - self.confidence_percentile))
+        else:
+            warmup_tasks_list = []
+            conf_bar = self.conf_threshold
+        print(f"conf_bar={conf_bar}", flush=True)
 
-            should_continue, sample_next_round = self.next_round_judge(
-                candidates, tasks_list)
-            candidates.extend(tasks_list)
+        if self.final_sample_num > 0:
+            print(f"begin final", flush=True)
+            final_tasks_list = yield from self.parallel_generate(
+                tasks, warmup=False, conf_bar=conf_bar, **kwargs)
+            print(f"end final", flush=True)
+        else:
+            final_tasks_list = []
 
-        return self.majority_vote(candidates, **kwargs)
+        finished_task_list = [
+            finished_tasks[0]
+            for finished_tasks in chain(warmup_tasks_list, final_tasks_list)
+        ]
+        print(f"len(finished_task_list)={len(finished_task_list)}", flush=True)
+        tasks[0].result = vote(finished_task_list)[self.vote_policy].result
+        print(f"end vote", flush=True)
 
-    def next_round_judge(self, candidates: List[Task],
-                         tasks_list: List[Task]) -> Tuple[bool, int]:
-        pass
+    def parallel_generate(self,
+                          tasks: List[Task],
+                          warmup: bool,
+                          conf_bar: Optional[float] = None,
+                          **kwargs):
+        # warmup will not stop early
+        generation_controller = self.warmup_generation_controller if warmup else self.final_generation_controller
+        sample_num = self.warmup_sample_num if warmup else self.final_sample_num
 
-    def majority_vote(self, candidates: List[Task],
-                      **kwargs) -> Tuple[int, str]:
-        pass
+        generation_controllers = [
+            generation_controller.clone() for _ in range(sample_num)
+        ]
+        if conf_bar is not None:
+            for generation_controller in generation_controllers:
+                generation_controller.confidence_info.conf_threshold = conf_bar
+        tasks_list = [copy.deepcopy(tasks) for _ in range(sample_num)]
+        generation_kwargs_list = [
+            copy.deepcopy(kwargs) for _ in range(sample_num)
+        ]
+        yield ParallelProcess(generation_controllers, tasks_list,
+                              generation_kwargs_list)
+
+        return tasks_list

--- a/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
@@ -19,19 +19,6 @@ class ConfidenceInfo:
     conf_threshold: float
 
 
-# This function is used to fake expand the logprobs_dict to the topk size
-# TODO: remove this function after the topk logprobs is supported with torch backend
-def fake_expand_logprobs_dict(logprobs_dict: Mapping[int, 'Logprob'],
-                              topk: int):
-    for token_id, logprob in logprobs_dict.items():
-        real_token_id = token_id
-
-    for i in range(topk - 1):
-        new_logprob = copy.deepcopy(logprob)
-        new_logprob.logprob = new_logprob.logprob / (i + 1)
-        logprobs_dict[real_token_id + i + 1] = new_logprob
-
-
 def update_confidence_info(confidence_info: ConfidenceInfo,
                            token_dict: Mapping[int, 'Logprob'], token_id: int):
     #print("fredw test update_confidence_info len(token_dict): " + str(len(token_dict)))
@@ -73,11 +60,9 @@ class DeepConfOfflineController(NativeGenerationController):
     def process(self, tasks: List[Task], **kwargs):
         assert len(
             tasks) == 1, "DeepConfOfflineController only supports one task"
-        tasks[0].num_logprobs = self.logprobs_topk
         yield from super().process(tasks, **kwargs)
         for logprobs_dict, token_id in zip(tasks[0].logprobs,
                                            tasks[0].output_tokens):
-            fake_expand_logprobs_dict(logprobs_dict, self.logprobs_topk)
             update_confidence_info(self.confidence_info, logprobs_dict,
                                    token_id)
         tasks[0].costimized_result_fields[
@@ -117,7 +102,6 @@ class DeepConfOnlineController(Controller):
             tasks) == 1, "DeepThinkOnlineController only supports one task"
         online_task = StreamGenerationTask.create_from_generation_task(tasks[0])
         online_task.streaming_step = self.confidence_info.conf_group_size
-        online_task.num_logprobs = self.logprobs_topk
         online_task.worker_tag = self.WorkerTag.GENERATION
 
         for key, value in self.sampling_params.items():
@@ -130,7 +114,6 @@ class DeepConfOnlineController(Controller):
             for i in range(last_step_index, len(online_task.output_tokens)):
                 logprobs_dict, token_id = online_task.logprobs[
                     i], online_task.output_tokens[i]
-                fake_expand_logprobs_dict(logprobs_dict, self.logprobs_topk)
                 update_confidence_info(self.confidence_info, logprobs_dict,
                                        token_id)
             if self.should_stop(self.confidence_info):

--- a/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_controller.py
@@ -1,11 +1,14 @@
 import copy
-from enum import Enum
-from dataclasses import dataclass, field
-from typing import List, Mapping
 from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Mapping, Tuple
 
-from tensorrt_llm.scaffolding import Controller, NativeGenerationController, MajorityVoteController,ParallelProcess, Task
-from tensorrt_llm.scaffolding.contrib.AsyncGeneration import StreamGenerationTask
+from tensorrt_llm.scaffolding import (Controller, MajorityVoteController,
+                                      NativeGenerationController,
+                                      ParallelProcess, StreamGenerationTask,
+                                      Task)
+
 
 @dataclass
 class ConfidenceInfo:
@@ -15,7 +18,23 @@ class ConfidenceInfo:
     conf_group_size: int
     conf_threshold: float
 
-def update_confidence_info(confidence_info: ConfidenceInfo, token_dict: Mapping[int, 'Logprob'], token_id: int):
+
+# This function is used to fake expand the logprobs_dict to the topk size
+# TODO: remove this function after the topk logprobs is supported with torch backend
+def fake_expand_logprobs_dict(logprobs_dict: Mapping[int, 'Logprob'],
+                              topk: int):
+    for token_id, logprob in logprobs_dict.items():
+        real_token_id = token_id
+
+    for i in range(topk - 1):
+        new_logprob = copy.deepcopy(logprob)
+        new_logprob.logprob = new_logprob.logprob / (i + 1)
+        logprobs_dict[real_token_id + i + 1] = new_logprob
+
+
+def update_confidence_info(confidence_info: ConfidenceInfo,
+                           token_dict: Mapping[int, 'Logprob'], token_id: int):
+    #print("fredw test update_confidence_info len(token_dict): " + str(len(token_dict)))
     if len(token_dict) > 1:
         sum = 0.0
         for logprob_token_id, logprob in token_dict.items():
@@ -30,75 +49,118 @@ def update_confidence_info(confidence_info: ConfidenceInfo, token_dict: Mapping[
     if len(confidence_info.conf_group_list) < confidence_info.conf_group_size:
         confidence_info.conf_grouped += new_conf
     else:
-        confidence_info.conf_grouped -= confidence_info.conf_group_list.popleft()
+        confidence_info.conf_grouped -= confidence_info.conf_group_list.popleft(
+        )
         confidence_info.conf_grouped += new_conf
 
 
 class DeepConfOfflineController(NativeGenerationController):
 
-    def __init__(self, 
-                 conf_group_size: int, 
-                 conf_threshold: float, 
-                 logprobs_topk:int = 20,
-                 sampling_params: dict = None, 
+    def __init__(self,
+                 conf_group_size: int,
+                 conf_threshold: float,
+                 logprobs_topk: int = 20,
+                 sampling_params: dict = None,
                  streaming: bool = False):
         super().__init__(sampling_params, streaming)
         self.logprobs_topk = logprobs_topk
-        self.confidence_info = ConfidenceInfo(conf_grouped=0.0, conf_list=[], conf_group_list=deque([]), conf_group_size=conf_group_size, conf_threshold=conf_threshold)
+        self.confidence_info = ConfidenceInfo(conf_grouped=0.0,
+                                              conf_list=[],
+                                              conf_group_list=deque([]),
+                                              conf_group_size=conf_group_size,
+                                              conf_threshold=conf_threshold)
 
     def process(self, tasks: List[Task], **kwargs):
-        assert (len(tasks) == 1, "DeepConfOfflineController only supports one task")
+        assert len(
+            tasks) == 1, "DeepConfOfflineController only supports one task"
         tasks[0].num_logprobs = self.logprobs_topk
         yield from super().process(tasks, **kwargs)
-        for logprobs_dict, token_id in zip(tasks[0].logprobs, tasks[0].output_tokens):
-            update_confidence_info(self.confidence_info, logprobs_dict, token_id)
-        tasks[0].costimized_result_fields['confidence_info'] = self.confidence_info
+        for logprobs_dict, token_id in zip(tasks[0].logprobs,
+                                           tasks[0].output_tokens):
+            fake_expand_logprobs_dict(logprobs_dict, self.logprobs_topk)
+            update_confidence_info(self.confidence_info, logprobs_dict,
+                                   token_id)
+        tasks[0].costimized_result_fields[
+            'confidence_info'] = self.confidence_info
 
 
 class DeepConfMajorityVoteController(MajorityVoteController):
-    
+
     # TODO: implement majority vote
     # ConfidenceInfo is on costimized_result_fields['confidence_info'] of each task
-    def majority_vote(self, candidates_tasks: List[Task], **kwargs) -> Tuple[int, str]:
+    def majority_vote(self, candidates_tasks: List[Task],
+                      **kwargs) -> Tuple[int, str]:
         pass
 
 
 class DeepConfOnlineController(Controller):
-    def __init__(self, conf_group_size: int, conf_threshold: float):
-        super().__init__()
-        self.confidence_info = ConfidenceInfo(conf_grouped=0.0, conf_list=[], conf_group_list=deque([]), conf_group_size=conf_group_size, conf_threshold=conf_threshold)
 
-    def clone(self):
-        return DeepConfOnlineController(self.conf_group_size, self.conf_threshold)
-    
+    class WorkerTag(Enum):
+        GENERATION = "generation"
+
+    def __init__(self,
+                 conf_group_size: int,
+                 conf_threshold: float,
+                 logprobs_topk: int = 20,
+                 sampling_params: dict = None):
+        super().__init__()
+        self.sampling_params = sampling_params
+        self.logprobs_topk = logprobs_topk
+        self.confidence_info = ConfidenceInfo(conf_grouped=0.0,
+                                              conf_list=[],
+                                              conf_group_list=deque([]),
+                                              conf_group_size=conf_group_size,
+                                              conf_threshold=conf_threshold)
+
     def process(self, tasks: List[Task], **kwargs):
-        assert (len(tasks) == 1, "DeepThinkOnlineController only supports one task")
+        assert len(
+            tasks) == 1, "DeepThinkOnlineController only supports one task"
         online_task = StreamGenerationTask.create_from_generation_task(tasks[0])
-        online_task.streaming_step = self.conf_group_size
+        online_task.streaming_step = self.confidence_info.conf_group_size
+        online_task.num_logprobs = self.logprobs_topk
+        online_task.worker_tag = self.WorkerTag.GENERATION
+
+        for key, value in self.sampling_params.items():
+            if getattr(online_task, key) is None:
+                setattr(online_task, key, value)
+
         last_step_index = 0
         while online_task.end_flag == False:
             yield [online_task]
             for i in range(last_step_index, len(online_task.output_tokens)):
-                logprobs_dict, token_id = online_task.logprobs[i], online_task.output_tokens[i]
-                update_confidence_info(self.confidence_info, logprobs_dict, token_id)
-            if self.should_stop(online_task.confidence_info):
+                logprobs_dict, token_id = online_task.logprobs[
+                    i], online_task.output_tokens[i]
+                fake_expand_logprobs_dict(logprobs_dict, self.logprobs_topk)
+                update_confidence_info(self.confidence_info, logprobs_dict,
+                                       token_id)
+            if self.should_stop(self.confidence_info):
                 online_task.cancel_flag = True
                 yield [online_task]
                 break
             last_step_index = len(online_task.output_tokens)
-        tasks[0].costimized_result_fields['confidence_info'] = self.confidence_info
+        tasks[0].result = online_task.result
+        tasks[0].costimized_result_fields[
+            'confidence_info'] = self.confidence_info
+
+    # TODO: implement should_stop
+    def should_stop(self, confidence_info: ConfidenceInfo) -> bool:
+        return False
 
 
 class AdaptiveMajorityVoteController(Controller):
-    def __init__(self, generation_controller: Controller, sample_num_per_round: int, max_sample_num: float):
+
+    def __init__(self, generation_controller: Controller,
+                 sample_num_per_round: int, max_sample_num: float):
         super().__init__()
         self.generation_controller = generation_controller
         self.sample_num_per_round = sample_num_per_round
         self.max_sample_num = max_sample_num
 
     def clone(self):
-        return AdaptiveMajorityVoteController(self.generation_controller.clone(), self.sample_num, self.max_sample_num)
-    
+        return AdaptiveMajorityVoteController(
+            self.generation_controller.clone(), self.sample_num,
+            self.max_sample_num)
+
     def process(self, tasks: List[Task], **kwargs):
         candidates = []
         should_continue = True
@@ -112,15 +174,19 @@ class AdaptiveMajorityVoteController(Controller):
             generation_kwargs_list = [
                 copy.deepcopy(kwargs) for _ in range(sample_num)
             ]
-            yield ParallelProcess(generation_controllers, tasks_list, generation_kwargs_list)
-            
-            should_continue, sample_next_round = self.next_round_judge(candidates, tasks_list)
+            yield ParallelProcess(generation_controllers, tasks_list,
+                                  generation_kwargs_list)
+
+            should_continue, sample_next_round = self.next_round_judge(
+                candidates, tasks_list)
             candidates.extend(tasks_list)
 
         return self.majority_vote(candidates, **kwargs)
 
-    def next_round_judge(self, candidates: List[Task], tasks_list: List[Task]) -> Tuple[bool, int]:
+    def next_round_judge(self, candidates: List[Task],
+                         tasks_list: List[Task]) -> Tuple[bool, int]:
         pass
 
-    def majority_vote(self, candidates: List[Task], **kwargs) -> Tuple[int, str]:
+    def majority_vote(self, candidates: List[Task],
+                      **kwargs) -> Tuple[int, str]:
         pass

--- a/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_utils.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepConf/deep_conf_utils.py
@@ -1,0 +1,178 @@
+import random
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from typing import List, Mapping
+
+import numpy as np
+
+from tensorrt_llm.scaffolding import Task, extract_answer_from_boxed
+
+
+@dataclass
+class ConfidenceInfo:
+    conf_grouped: float = 0.0
+    conf_group_size: int = 128
+    conf_threshold: float = 0.0
+    conf_list: list[float] = field(default_factory=list)
+    conf_group_list: deque[float] = field(default_factory=deque)
+    avg_conf_group_list: list[float] = field(default_factory=list)
+
+    def get_min_conf_grouped(self):
+        if len(self.avg_conf_group_list) == 0:
+            print(
+                f"Warning: no valid conf group yet, maybe you should decrease conf_group_size"
+            )
+            return self.conf_threshold
+        return min(self.avg_conf_group_list)
+
+    def should_stop(self):
+        return self.avg_conf_group_list[-1] < self.conf_threshold if len(
+            self.conf_list) >= self.conf_group_size else False
+
+    def get_statistics(self,
+                       tail_tokens: int = 2048,
+                       bottom_percent: float = 0.1):
+        # global mean confidence
+        self.mean_conf = np.mean(self.conf_list)
+
+        # tail mean confidence
+        tail_conf_list = self.conf_list[-tail_tokens:] if len(
+            self.conf_list) > tail_tokens else self.conf_list
+        self.tail_mean_conf = np.mean(tail_conf_list)
+
+        # bottom window mean confidence and min window confidence
+        if len(self.avg_conf_group_list) == 0:
+            self.bottom_window_mean_conf = np.mean(self.conf_list)
+            self.min_window_conf = self.bottom_window_mean_conf
+        else:
+            num_bottom = max(
+                1, int(len(self.avg_conf_group_list) * bottom_percent))
+            if num_bottom == 1:
+                self.bottom_window_mean_conf = np.min(self.avg_conf_group_list)
+            else:
+                self.bottom_window_mean_conf = np.mean(
+                    np.partition(self.avg_conf_group_list,
+                                 num_bottom - 1)[:num_bottom])
+            self.min_window_conf = np.min(self.avg_conf_group_list)
+
+    def update_confidence_info(self, token_dict: Mapping[int, 'Logprob'],
+                               token_id: int):
+        mean_logprob = np.mean(
+            [logprob_obj.logprob for logprob_obj in token_dict.values()])
+        new_conf = round(-mean_logprob, 3)
+        self.conf_list.append(new_conf)
+        self.conf_grouped += new_conf
+        self.conf_group_list.append(new_conf)
+        if len(self.conf_group_list) > self.conf_group_size:
+            self.conf_grouped -= self.conf_group_list.popleft()
+        if len(self.conf_group_list) == self.conf_group_size:
+            self.avg_conf_group_list.append(self.conf_grouped /
+                                            self.conf_group_size)
+
+
+def basic_majority_vote(tasks: List[Task], answers, **kwargs) -> Task:
+    majority_answer = Counter(answers).most_common(1)[0][0]
+    return tasks[answers.index(majority_answer)]
+
+
+def weighted_majority_vote(tasks: List[Task],
+                           answers,
+                           confidences,
+                           filter_top_percent=1.0,
+                           type="",
+                           **kwargs) -> Task:
+    if filter_top_percent < 1:
+        sorted_indices = np.argsort(confidences)[::-1]
+        num_keep = max(1, int(len(confidences) * filter_top_percent))
+        save_indices = sorted_indices[:num_keep].tolist()
+
+        tasks = [tasks[i] for i in save_indices]
+        answers = [answers[i] for i in save_indices]
+        confidences = [confidences[i] for i in save_indices]
+
+    print(f"{type=} {filter_top_percent=} has {len(tasks)} valid tasks",
+          flush=True)
+
+    answer_to_weights = {}
+    for answer, confidence in zip(answers, confidences):
+        answer_to_weights[answer] = answer_to_weights.get(answer,
+                                                          0.0) + confidence
+    majority_answer = max(answer_to_weights, key=answer_to_weights.get)
+    return tasks[answers.index(majority_answer)]
+
+
+def majority_vote(tasks_list: List[List[Task]], vote_policy: str = 'majority'):
+    tasks = [tasks[0] for tasks in tasks_list]
+    for task in tasks:
+        task.costimized_result_fields[
+            'extracted_answer'] = extract_answer_from_boxed(task.output_str)
+        task.costimized_result_fields['confidence_info'].get_statistics()
+    valid_tasks = [
+        task for task in tasks
+        if task.costimized_result_fields['extracted_answer']
+    ]
+
+    if len(valid_tasks) == 0:
+        print(
+            "Warning: No valid tasks, maybe you should increase max_output_len, a random task will be returned"
+        )
+        return random.choice(tasks)
+
+    answers = [
+        task.costimized_result_fields['extracted_answer']
+        for task in valid_tasks
+    ]
+    confidences = [
+        task.costimized_result_fields['confidence_info'] for task in valid_tasks
+    ]
+
+    match vote_policy:
+        case 'majority':
+            return basic_majority_vote(valid_tasks, answers=answers)
+        case 'mean_confidence_weighted':
+            mean_confidences = [conf.mean_conf for conf in confidences]
+            return weighted_majority_vote(valid_tasks,
+                                          answers=answers,
+                                          confidences=mean_confidences,
+                                          type='mean_confidence_weighted')
+        case 'tail_confidence_weighted':
+            tail_confidences = [conf.tail_mean_conf for conf in confidences]
+            return weighted_majority_vote(valid_tasks,
+                                          answers=answers,
+                                          confidences=tail_confidences,
+                                          type='tail_confidence_weighted')
+        case 'bottom_window_weighted':
+            bottom_window_confidences = [
+                conf.bottom_window_mean_conf for conf in confidences
+            ]
+            return weighted_majority_vote(valid_tasks,
+                                          answers=answers,
+                                          confidences=bottom_window_confidences,
+                                          type='bottom_window_weighted')
+        case 'min_window_weighted':
+            min_window_confidences = [
+                conf.min_window_conf for conf in confidences
+            ]
+            return weighted_majority_vote(valid_tasks,
+                                          answers=answers,
+                                          confidences=min_window_confidences,
+                                          type='min_window_weighted')
+        case 'top10_tail_filtered':
+            tail_confidences = [conf.tail_mean_conf for conf in confidences]
+            return weighted_majority_vote(valid_tasks,
+                                          answers=answers,
+                                          confidences=tail_confidences,
+                                          filter_top_percent=0.1,
+                                          type='tail_confidence_weighted')
+        case 'top10_bottom_window_filtered':
+            bottom_window_confidences = [
+                conf.bottom_window_mean_conf for conf in confidences
+            ]
+            return weighted_majority_vote(valid_tasks,
+                                          answers=answers,
+                                          confidences=bottom_window_confidences,
+                                          filter_top_percent=0.1,
+                                          type='bottom_window_weighted')
+        case _:
+            raise NotImplementedError(
+                f"Vote policy '{vote_policy}' is not implemented")

--- a/tensorrt_llm/scaffolding/contrib/DeepThink/deep_think_controller.py
+++ b/tensorrt_llm/scaffolding/contrib/DeepThink/deep_think_controller.py
@@ -1,0 +1,79 @@
+import copy
+from enum import Enum
+from dataclasses import dataclass, field
+from typing import List
+from collections import deque
+
+from tensorrt_llm.scaffolding import Controller, NativeGenerationController, ParallelProcess, Task
+
+@dataclass
+class ConfidenceInfo:
+    conf_grouped: float
+    conf_list: list[float]
+    conf_group_list: deque[float]
+    conf_group_size: int
+    conf_threshold: float
+
+def update_confidence_info(confidence_info: ConfidenceInfo, logprobs: List[float]):
+    if len(logprobs) > 1:
+        new_conf = -sum(logprobs[1:]) / len(logprobs[1:])
+    else:
+        new_conf = 0.0
+
+    confidence_info.conf_list.append(new_conf)
+
+    if len(confidence_info.conf_group_list) < confidence_info.conf_group_size:
+        confidence_info.conf_group_list.append(new_conf)
+        confidence_info.conf_grouped += new_conf
+    else:
+        confidence_info.conf_grouped -= confidence_info.conf_group_list.popleft()
+        confidence_info.conf_group_list.append(new_conf)
+        confidence_info.conf_grouped += new_conf
+
+
+class DeepThinkOfflineController(NativeGenerationController):
+
+    def __init__(self, conf_group_size: int, conf_threshold: float, sampling_params: dict = None, streaming: bool = False):
+        super().__init__(sampling_params, streaming)
+        self.confidence_info = ConfidenceInfo(conf_grouped=0.0, conf_list=[], conf_group_list=deque([]), conf_group_size=conf_group_size, conf_threshold=conf_threshold)
+
+    def process(self, tasks: List[Task], **kwargs):
+        yield from super().process(tasks, **kwargs)
+        assert (len(tasks) == 1, "DeepThinkOfflineController only supports one task")
+        for logprobs in tasks[0].result.outputs[0].logprobs:
+            update_confidence_info(self.confidence_info, logprobs)
+
+
+class DeepThinkMajorityVoteController(Controller):
+    def __init__(self, generation_controller: DeepThinkOfflineController,
+                 sample_num: int = 1):
+        self.generation_controller = generation_controller
+        self.sample_num = sample_num
+
+    def clone(self):
+        return DeepThinkMajorityVoteController(self.generation_controller.clone(), self.default_sample_num)
+
+    def process(self, tasks: List[Task], generation_kwargs: dict = {}):
+        generation_controllers = [
+            self.generation_controller.clone() for _ in range(self.sample_num)
+        ]
+        tasks_list = [copy.deepcopy(tasks) for _ in range(self.sample_num)]
+        generation_kwargs_list = [
+            copy.deepcopy(generation_kwargs) for _ in range(self.sample_num)
+        ]
+
+        yield ParallelProcess(generation_controllers, tasks_list, generation_kwargs_list)
+
+        candidates = [tasks[0].output_str for tasks in tasks_list]
+        return majority_answer
+
+
+class DeepThinkOnlineController(Controller):
+    def __init__(self, generation_controller: DeepThinkOfflineController,
+                 sample_num: int = 1):
+        self.generation_controller = generation_controller
+        self.sample_num = sample_num
+
+    def clone(self):
+        return DeepThinkOnlineController(self.generation_controller.clone(), self.sample_num)
+        

--- a/tensorrt_llm/scaffolding/controller.py
+++ b/tensorrt_llm/scaffolding/controller.py
@@ -230,15 +230,15 @@ class MajorityVoteController(Controller):
         yield ParallelProcess(generation_controllers, tasks_list,
                               generation_kwargs_list)
 
-        candidates = [tasks[0].output_str for tasks in tasks_list]
         majority_index, majority_answer = self.majority_vote(
-            candidates, **majority_vote_kwargs)
+            tasks_list, **majority_vote_kwargs)
 
         assert isinstance(majority_answer, str), "majority_vote failed"
         # The task returned by majority vote does not have output_tokens and logits.
         tasks[0].result = tasks_list[majority_index][0].result
 
-    def majority_vote(self, candidates: List[str], **kwargs) -> Tuple[int, str]:
+    def majority_vote(self, candidates_tasks: List[Task], **kwargs) -> Tuple[int, str]:
+        candidates = [task.output_str for task in candidates_tasks]
         return get_digit_majority_vote_result(candidates)
 
 

--- a/tensorrt_llm/scaffolding/scaffolding_llm.py
+++ b/tensorrt_llm/scaffolding/scaffolding_llm.py
@@ -208,7 +208,7 @@ class ScaffoldingLlm:
 
     def shutdown(self, shutdown_workers=False):
 
-        def shutdown_workers():
+        def shutdown_workers_func():
             for worker in self.workers.values():
                 worker.shutdown()
 
@@ -228,4 +228,4 @@ class ScaffoldingLlm:
             self.shutdown_event.set()
 
         if shutdown_workers:
-            shutdown_workers()
+            shutdown_workers_func()

--- a/tensorrt_llm/scaffolding/scaffolding_llm.py
+++ b/tensorrt_llm/scaffolding/scaffolding_llm.py
@@ -175,13 +175,19 @@ class ScaffoldingLlm:
         result = ScaffoldingResult(self.streaming_event)
 
         async def put_request():
-            request = ScaffoldingRequest(
-                prompt=prompt,
-                kwargs={},
-                result=result,
-                controller=self.prototype_controller.clone())
-
-            await self.task_queue.put(request)
+            try:
+                request = ScaffoldingRequest(
+                    prompt=prompt,
+                    kwargs={},
+                    result=result,
+                    controller=self.prototype_controller.clone())
+            except Exception as e:
+                self.task_queue.put(None)
+                print(
+                    f"Error: clone controller failed: {e} \n {traceback.format_exc()}"
+                )
+            else:
+                await self.task_queue.put(request)
 
         asyncio.run_coroutine_threadsafe(put_request(), self.loop)
 

--- a/tensorrt_llm/scaffolding/task.py
+++ b/tensorrt_llm/scaffolding/task.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Union
 
 import torch
 
-from tensorrt_llm.executor.result import GenerationResult
+from tensorrt_llm.executor.result import GenerationResult, TokenLogprobs
 
 
 @dataclass
@@ -64,6 +64,7 @@ class GenerationTask(Task):
     # result field
     # link to TRTLLM's GenerationResult, for async update in streaming mode
     _result: Optional[GenerationResult] = None
+    costimized_result_fields: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def result(self) -> GenerationResult:
@@ -96,7 +97,7 @@ class GenerationTask(Task):
             0].cumulative_logprob if self._result else None
 
     @property
-    def logprobs(self) -> Optional[List[float]]:
+    def logprobs(self) -> Optional[TokenLogprobs]:
         return self._result.outputs[0].logprobs if self._result else None
 
     @property

--- a/tensorrt_llm/scaffolding/task.py
+++ b/tensorrt_llm/scaffolding/task.py
@@ -1,6 +1,7 @@
+import copy
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 
@@ -114,6 +115,31 @@ class GenerationTask(Task):
 
     def create_scaffolding_output(self) -> GenerationResult:
         return self._result
+
+
+@dataclass
+class StreamGenerationTask(GenerationTask):
+    # input field
+    # if the flag is set to True, the worker will cancel the generation work
+    cancel_flag: Optional[bool] = field(default=False)
+    # the task will be returned to the controller with at least new streaming_step tokens
+    # if the streaming_step is set to 0,
+    # the task will be returned to the controller immediately with
+    # new tokens that have already been generated.
+    streaming_step: Optional[int] = field(default=1)
+
+    #result field
+    # worker set this field and identify the same task by this field
+    request_handle: Any = field(default=None)
+    # worker set this field to True when the generation is finished
+    end_flag: bool = field(default=False)
+
+    @staticmethod
+    def create_from_generation_task(
+            task: GenerationTask) -> "StreamGenerationTask":
+        stream_task = StreamGenerationTask()
+        stream_task.__dict__ = copy.deepcopy(task.__dict__)
+        return stream_task
 
 
 @dataclass

--- a/tensorrt_llm/scaffolding/task.py
+++ b/tensorrt_llm/scaffolding/task.py
@@ -135,10 +135,11 @@ class StreamGenerationTask(GenerationTask):
     end_flag: bool = field(default=False)
 
     @staticmethod
-    def create_from_generation_task(
-            task: GenerationTask) -> "StreamGenerationTask":
+    def create_from_generation_task(task: GenerationTask,
+                                    streaming_step) -> "StreamGenerationTask":
         stream_task = StreamGenerationTask()
         stream_task.__dict__ = copy.deepcopy(task.__dict__)
+        stream_task.streaming_step = streaming_step
         return stream_task
 
 

--- a/tensorrt_llm/scaffolding/worker.py
+++ b/tensorrt_llm/scaffolding/worker.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import ABC
 from typing import Callable
 
@@ -9,7 +10,7 @@ from tensorrt_llm.executor import GenerationExecutor
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 from tensorrt_llm.sampling_params import SamplingParams
 
-from .task import GenerationTask, Task, TaskStatus
+from .task import GenerationTask, StreamGenerationTask, Task, TaskStatus
 
 ExecutorCls = GenerationExecutor
 
@@ -201,8 +202,47 @@ class TRTLLMWorker(Worker):
         # TODO: error handle
         return TaskStatus.SUCCESS
 
+    async def stream_generation_handler(
+            self, task: StreamGenerationTask) -> TaskStatus:
+
+        async def get_step_or_more_tokens(task: StreamGenerationTask):
+            if task.cancel_flag:
+                task.end_flag = True
+                task.request_handle.abort()
+                return TaskStatus.SUCCESS
+
+            for _ in range(task.streaming_step):
+                await task.request_handle._aresult_step()
+                if task.request_handle._done:
+                    break
+            while not task.request_handle._done:
+                async_task = asyncio.create_task(
+                    task.request_handle._aresult_step())
+                if not async_task.done():
+                    async_task.cancel()
+                    break
+            '''
+            task.output_str = task.request_handle.outputs[0].text
+            task.output_tokens = task.request_handle.outputs[0].token_ids
+            task.cumulative_logprob = task.request_handle.outputs[
+                0].cumulative_logprob
+            task.logprobs = task.request_handle.outputs[0].logprobs
+            '''
+            if task.request_handle._done:
+                task.end_flag = True
+
+        sampling_params = self.convert_task_params(task)
+        if task.request_handle is None:
+            task.request_handle = self.llm.generate_async(
+                task.input_str, sampling_params=sampling_params, streaming=True)
+            task._result = task.request_handle
+        await get_step_or_more_tokens(task)
+
     def shutdown(self):
         if self.own_llm:
             self.llm.shutdown()
 
-    task_handlers = {GenerationTask: generation_handler}
+    task_handlers = {
+        GenerationTask: generation_handler,
+        StreamGenerationTask: stream_generation_handler
+    }


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
